### PR TITLE
Bug fix during testing

### DIFF
--- a/strato/backends/_aws.py
+++ b/strato/backends/_aws.py
@@ -11,9 +11,18 @@ class AWSBackend:
         call_args.extend(['cp', '--only-show-errors'])
         if recursive:
             call_args.append('--recursive')
-        call_args.extend(filenames)
-        print(' '.join(call_args))
-        check_call(call_args)
+
+        source_files = filenames[:-1]
+        target = filenames[-1]
+        if len(source_files) > 1 and target[-1] != '/':
+            target += '/'
+
+        # Copy files one by one.
+        for source in source_files:
+            subcall_args = call_args.copy()
+            subcall_args.extend([source, target])
+            print(' '.join(subcall_args))
+            check_call(subcall_args)
 
     def sync(self, source, target):
         call_args = self._call_prefix.copy()
@@ -26,9 +35,13 @@ class AWSBackend:
         call_args.extend(['rm', '--quiet'])
         if recursive:
             call_args.append('--recursive')
-        call_args.extend(filenames)
-        print(' '.join(call_args))
-        check_call(call_args)
+
+        # Delete files one by one.
+        for f in filenames:
+            subcall_args = call_args.copy()
+            subcall_args.append(f)
+            print(' '.join(subcall_args))
+            check_call(subcall_args)
 
     def stat(self, filename):
         call_args = self._call_prefix.copy()

--- a/strato/backends/_aws.py
+++ b/strato/backends/_aws.py
@@ -1,3 +1,4 @@
+import os
 from subprocess import check_call
 
 
@@ -6,11 +7,9 @@ class AWSBackend:
         self._backend = 'aws'
         self._call_prefix = ['aws', 's3']
 
-    def copy(self, recursive, filenames):
+    def copy(self, filenames):
         call_args = self._call_prefix.copy()
         call_args.extend(['cp', '--only-show-errors'])
-        if recursive:
-            call_args.append('--recursive')
 
         source_files = filenames[:-1]
         target = filenames[-1]
@@ -20,30 +19,37 @@ class AWSBackend:
         # Copy files one by one.
         for source in source_files:
             subcall_args = call_args.copy()
-            subcall_args.extend([source, target])
+            subcall_target = target
+            if source[-1] == '/':
+                subcall_args.append('--recursive')
+                if subcall_target[-1] != '/':
+                    subcall_target = subcall_target + '/' + os.path.basename(source)
+                else:
+                    subcall_target = subcall_target + os.path.basename(source)
+            subcall_args.extend([source, subcall_target])
             print(' '.join(subcall_args))
             check_call(subcall_args)
 
     def sync(self, source, target):
         call_args = self._call_prefix.copy()
-        call_args.extend(['sync', '--delete', source, target])
+        call_args.extend(['sync', '--delete', '--only-show-errors', source, target])
         print(' '.join(call_args))
         check_call(call_args)
 
-    def delete(self, recursive, filenames):
+    def delete(self, filenames):
         call_args = self._call_prefix.copy()
-        call_args.extend(['rm', '--quiet'])
-        if recursive:
-            call_args.append('--recursive')
+        call_args.extend(['rm', '--only-show-errors'])
 
         # Delete files one by one.
         for f in filenames:
             subcall_args = call_args.copy()
+            if f[-1] == '/':
+                subcall_args.append('--recursive')
             subcall_args.append(f)
             print(' '.join(subcall_args))
             check_call(subcall_args)
 
     def stat(self, filename):
         call_args = self._call_prefix.copy()
-        call_args.extend(['ls', filename])
+        call_args.extend(['cp', '--quiet', '--dryrun', filename, 'null'])
         check_call(call_args)

--- a/strato/backends/_gcp.py
+++ b/strato/backends/_gcp.py
@@ -32,7 +32,7 @@ class GCPBackend:
         call_args.append('rm')
         if recursive:
             call_args.append('-r')
-        call_args.extend(call_args)
+        call_args.extend(filenames)
         print(' '.join(call_args))
         check_call(call_args)
 

--- a/strato/backends/_local.py
+++ b/strato/backends/_local.py
@@ -1,3 +1,4 @@
+import os
 from subprocess import check_call
 
 class LocalBackend:
@@ -19,7 +20,8 @@ class LocalBackend:
         check_call(call_args)
 
     def sync(self, source, target):
-        call_args = ['rsync', '-r', source, target]
+        target = os.path.dirname(target)
+        call_args = ['rsync', '-r', '--delete', source, target]
         print(' '.join(call_args))
         check_call(call_args)
 

--- a/strato/commands/cp.py
+++ b/strato/commands/cp.py
@@ -7,7 +7,7 @@ def copy_files(backend, recursive, parallel, filenames):
     if backend == 'aws':
         from strato.backends import AWSBackend
         be = AWSBackend()
-        be.copy(recursive, filenames)
+        be.copy(filenames)
     elif backend == 'gcp':
         from strato.backends import GCPBackend
         be = GCPBackend()
@@ -19,11 +19,11 @@ def copy_files(backend, recursive, parallel, filenames):
 
 
 def main(argsv):
-    parser = argparse.ArgumentParser(description="Copy files or folders.")
+    parser = argparse.ArgumentParser(description="Copy files or folders. Notice that for AWS backend, a folder link must end with a slash '/'.")
     parser.add_argument('--backend', dest='backend', action='store', required=True, help='Specify which backend to use. Available options: aws, gcp, local.')
-    parser.add_argument('-r', dest='recursive', action='store_true', help="Recursive copy.")
+    parser.add_argument('-r', dest='recursive', action='store_true', help="Recursive copy. Not needed for AWS backend.")
     parser.add_argument('-m', dest='parallel', action='store_true', help="Run operations in parallel. Only available for GCP backend.")
     parser.add_argument('files', metavar='filenames', type=str, nargs='+', help='List of file paths.')
 
     args = parser.parse_args(argsv)
-    copy_files(args.backend, args.recursive, args.parallel, args.filenames)
+    copy_files(args.backend, args.recursive, args.parallel, args.files)

--- a/strato/commands/rm.py
+++ b/strato/commands/rm.py
@@ -7,7 +7,7 @@ def delete_files(backend, recursive, parallel, filenames):
     if backend == 'aws':
         from strato.backends import AWSBackend
         be = AWSBackend()
-        be.delete(recursive, filenames)
+        be.delete(filenames)
     elif backend == 'gcp':
         from strato.backends import GCPBackend
         be = GCPBackend()
@@ -18,11 +18,11 @@ def delete_files(backend, recursive, parallel, filenames):
         be.delete(recursive, filenames)
 
 def main(argsv):
-    parser = argparse.ArgumentParser(description="Delete files or folders.")
+    parser = argparse.ArgumentParser(description="Delete files or folders. Notice that for AWS backend, a folder link must end with a slash '/'.")
     parser.add_argument('--backend', dest='backend', action='store', required=True, help='Specify which backend to use. Available options: aws, gcp, local.')
-    parser.add_argument('-r', dest='recursive', action='store_true', help="Recursive deletion.")
+    parser.add_argument('-r', dest='recursive', action='store_true', help="Recursive deletion. Not needed for AWS backend.")
     parser.add_argument('-m', dest='parallel', action='store_true', help="Run operations in parallel. Only available for GCP backend.")
     parser.add_argument('files', metavar='filenames', type=str, nargs='+', help='List of file paths.')
 
     args = parser.parse_args(argsv)
-    delete_files(args.backend, args.recursive, args.parallel, args.filenames)
+    delete_files(args.backend, args.recursive, args.parallel, args.files)


### PR DESCRIPTION
* AWS backend:
  * `cp` command for each source file. Require a trailing slash (`/`) for a directory link. This is because applying `--recursive` option globally would fail for files. Then no need to manually set `-r` option, because Stratocumulus will attach the option depending on the file type.
  * `rm`: Similarly as `cp`.
  * `exists`: Use `cp --quiet --dryrun`, which exits 0 without displaying if the file/directory exists, and fails if not. The previous `aws s3 ls` always exits 0.
* Local backend:
  * `sync`: Synchronize the source directory with the parent directory of the target. This is because Samba's `rsync` command's behavior is different from `aws sync` or `gsutil rsync`.