### PR TITLE
make behavior of sync command consistent across backends

### DIFF
--- a/strato/backends/_gcp.py
+++ b/strato/backends/_gcp.py
@@ -20,6 +20,12 @@ class GCPBackend:
         check_call(call_args)
 
     def sync(self, parallel, ionice, source, target):
+        # If target folder is local.
+        if len(target.split('://')) == 1:
+            import os
+            if not os.path.exists(target):
+                os.mkdir(target)
+
         call_args = ['ionice', '-c', '2', '-n', '7'] if ionice and (shutil.which('ionice') != None) else []
         call_args += self._call_prefix
         if parallel:


### PR DESCRIPTION
### Failed case

`strato sync --backend gcp -m gs://<gs-path> <local-path>` 

fails if `<local-path>` doesn't exist.

But for AWS and local backends, they will first create `<local-path>` if not exists, then do `rsync`.

### Solution

For GCP backend, if the target folder is a local path, detect if it exists. If not, create one before `rsync`.