### PR TITLE
Improvement on `exists` and `cp` commands

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 argparse
+boto3

--- a/strato/backends/_gcp.py
+++ b/strato/backends/_gcp.py
@@ -46,6 +46,7 @@ class GCPBackend:
         check_call(call_args)
 
     def stat(self, filename):
+        assert filename.startswith("gs://"), "Must be a GS URI!"
         is_folder = True if filename[-1]=='/' else False
 
         if is_folder:

--- a/strato/backends/_gcp.py
+++ b/strato/backends/_gcp.py
@@ -46,5 +46,11 @@ class GCPBackend:
         check_call(call_args)
 
     def stat(self, filename):
-        call_args = ['gsutil', '-q', 'stat', filename]
+        is_folder = True if filename[-1]=='/' else False
+
+        if is_folder:
+            call_args = ['gsutil', '-q', 'stat', filename + '*']
+        else:
+            call_args = ['gsutil', '-q', 'stat', filename]
+
         check_call(call_args)

--- a/strato/commands/exists.py
+++ b/strato/commands/exists.py
@@ -18,7 +18,7 @@ def check_status(backend, filename):
         be.stat(filename)
 
 def main(argsv):
-    parser = argparse.ArgumentParser(description="Check if a file or folder's path exists. Break if doesn't exist.")
+    parser = argparse.ArgumentParser(description="Check if a file or folder's path exists. Break if doesn't exist. Notice that a folder path must end with '/'.")
     parser.add_argument('--backend', dest='backend', action='store', required=True, help='Specify which backend to use. Available options: aws, gcp, local.')
     parser.add_argument('filename', metavar='filename', type=str, help='A file or folder path.')
 


### PR DESCRIPTION
For GCP backend:
* `exists` command now works for GS folder URIs.

For AWS backend:
* `exists` command now works for S3 folder URIs: use S3 REST API to check the existence of S3 folders.
* `cp` command now accepts copying multiple S3 files via wildcards.