### PR TITLE
Add `--quiet` option

### DIFF
--- a/strato/backends/_aws.py
+++ b/strato/backends/_aws.py
@@ -22,7 +22,7 @@ class AWSBackend:
         self._backend = 'aws'
         self._call_prefix = ['aws', 's3']
 
-    def copy(self, ionice, filenames, profile: Optional[str] = None):
+    def copy(self, ionice, filenames, profile, quiet):
         call_args = ['ionice', '-c', '2', '-n', '7'] if ionice and (shutil.which('ionice') != None) else []
         call_args += self._call_prefix
         call_args.extend(['cp', '--only-show-errors'])
@@ -49,19 +49,21 @@ class AWSBackend:
                 else:
                     subcall_target = subcall_target + os.path.basename(source)
             subcall_args.extend([source, subcall_target])
-            print(' '.join(subcall_args))
+            if not quiet:
+                print(' '.join(subcall_args))
             check_call(subcall_args)
 
-    def sync(self, ionice, source, target, profile: Optional[str] = None):
+    def sync(self, ionice, source, target, profile, quiet):
         call_args = ['ionice', '-c', '2', '-n', '7'] if ionice and (shutil.which('ionice') != None) else []
         call_args += self._call_prefix
         if profile is not None:
             call_args.extend(['--profile', profile])
         call_args.extend(['sync', '--delete', '--only-show-errors', source, target])
-        print(' '.join(call_args))
+        if not quiet:
+            print(' '.join(call_args))
         check_call(call_args)
 
-    def delete(self, filenames, profile: Optional[str] = None):
+    def delete(self, filenames, profile, quiet):
         call_args = self._call_prefix.copy()
         call_args.extend(['rm', '--only-show-errors'])
 
@@ -74,10 +76,11 @@ class AWSBackend:
             if f[-1] == '/':
                 subcall_args.append('--recursive')
             subcall_args.append(f)
-            print(' '.join(subcall_args))
+            if not quiet:
+                print(' '.join(subcall_args))
             check_call(subcall_args)
 
-    def stat(self, filename, profile: Optional[str] = None):
+    def stat(self, filename, profile):
         assert filename.startswith("s3://"), "Must be an S3 URI!"
 
         call_args = self._call_prefix.copy()

--- a/strato/backends/_gcp.py
+++ b/strato/backends/_gcp.py
@@ -7,7 +7,7 @@ class GCPBackend:
         self._backend = 'gcp'
         self._call_prefix = ['gsutil', '-q', '-o', 'GSUtil:parallel_composite_upload_threshold=150M']
 
-    def copy(self, recursive, parallel, ionice, filenames):
+    def copy(self, recursive, parallel, ionice, filenames, quiet):
         call_args = ['ionice', '-c', '2', '-n', '7'] if ionice and (shutil.which('ionice') != None) else []
         call_args += self._call_prefix
         if parallel:
@@ -16,10 +16,11 @@ class GCPBackend:
         if recursive:
             call_args.append('-r')
         call_args.extend(filenames)
-        print(' '.join(call_args))
+        if not quiet:
+            print(' '.join(call_args))
         check_call(call_args)
 
-    def sync(self, parallel, ionice, source, target):
+    def sync(self, parallel, ionice, source, target, quiet):
         # If target folder is local.
         if len(target.split('://')) == 1:
             import os
@@ -31,10 +32,11 @@ class GCPBackend:
         if parallel:
             call_args.append('-m')
         call_args.extend(['rsync', '-d', '-r', source, target])
-        print(' '.join(call_args))
+        if not quiet:
+            print(' '.join(call_args))
         check_call(call_args)
 
-    def delete(self, recursive, parallel, filenames):
+    def delete(self, recursive, parallel, filenames, quiet):
         call_args = self._call_prefix.copy()
         if parallel:
             call_args.append('-m')
@@ -42,7 +44,8 @@ class GCPBackend:
         if recursive:
             call_args.append('-r')
         call_args.extend(filenames)
-        print(' '.join(call_args))
+        if not quiet:
+            print(' '.join(call_args))
         check_call(call_args)
 
     def stat(self, filename):

--- a/strato/backends/_local.py
+++ b/strato/backends/_local.py
@@ -5,7 +5,7 @@ class LocalBackend:
     def __init__(self):
         self._backend = 'local'
 
-    def copy(self, recursive, ionice, filenames):
+    def copy(self, recursive, ionice, filenames, quiet):
         assert len(filenames) >= 2, "Either source or destination is missing!"
         target = filenames[-1]
         call_args1 = ['mkdir', '-p', target]
@@ -17,22 +17,25 @@ class LocalBackend:
         if recursive:
             call_args.append('-r')
         call_args.extend(filenames)
-        print(' '.join(call_args))
+        if not quiet:
+            print(' '.join(call_args))
         check_call(call_args)
 
-    def sync(self, ionice, source, target):
+    def sync(self, ionice, source, target, quiet):
         target = os.path.dirname(target)
         call_args = ['ionice', '-c', '2', '-n', '7'] if ionice and (shutil.which('ionice')) != None else []
         call_args += ['rsync', '-r', '--delete', source, target]
-        print(' '.join(call_args))
+        if not quiet:
+            print(' '.join(call_args))
         check_call(call_args)
 
-    def delete(self, recursive, filenames):
+    def delete(self, recursive, filenames, quiet):
         call_args = ['rm']
         if recursive:
             call_args.append('-r')
         call_args.extend(filenames)
-        print(' '.join(call_args))
+        if not quiet:
+            print(' '.join(call_args))
         check_call(call_args)
 
     def stat(self, filename):

--- a/strato/commands/cp.py
+++ b/strato/commands/cp.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Optional
 
 example_text = """Examples:
   # AWS upload
@@ -17,21 +16,22 @@ example_text = """Examples:
   strato cp --backend local -r file1 folder2 /target_folder/
 """
 
-def copy_files(backend, recursive, parallel, ionice, filenames, profile: Optional[str] = None):
+def copy_files(backend, recursive, parallel, ionice, filenames, profile, quiet):
     assert backend in ['aws', 'gcp', 'local'], "Backend not supported!"
+    print(quiet)
 
     if backend == 'aws':
         from strato.backends import AWSBackend
         be = AWSBackend()
-        be.copy(ionice, filenames, profile)
+        be.copy(ionice, filenames, profile, quiet)
     elif backend == 'gcp':
         from strato.backends import GCPBackend
         be = GCPBackend()
-        be.copy(recursive, parallel, ionice, filenames)
+        be.copy(recursive, parallel, ionice, filenames, quiet)
     else:
         from strato.backends import LocalBackend
         be = LocalBackend()
-        be.copy(recursive, ionice, filenames)
+        be.copy(recursive, ionice, filenames, quiet)
 
 
 def main(argsv):
@@ -45,7 +45,8 @@ def main(argsv):
     parser.add_argument('-m', dest='parallel', action='store_true', help="Run operations in parallel. Only available for GCP backend.")
     parser.add_argument('--ionice', dest='ionice', action='store_true', help="Run with ionice to avoid monopolizing local disk's I/O. Only available for Linux.")
     parser.add_argument('--profile', dest='profile', type=str, action='store', help='AWS profile. Only works for aws backend, and use the default profile if not provided.')
+    parser.add_argument('--quiet', dest='quiet', action='store_true', help="Hide the underlying cloud command.")
     parser.add_argument('files', metavar='filenames', type=str, nargs='+', help='List of file paths.')
 
     args = parser.parse_args(argsv)
-    copy_files(args.backend, args.recursive, args.parallel, args.ionice, args.files, args.profile)
+    copy_files(args.backend, args.recursive, args.parallel, args.ionice, args.files, args.profile, args.quiet)

--- a/strato/commands/exists.py
+++ b/strato/commands/exists.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Optional
 
 
 example_text = """Examples:
@@ -8,7 +7,7 @@ example_text = """Examples:
   strato exists --backend local folder2/
 """
 
-def check_status(backend, filename, profile: Optional[str] = None):
+def check_status(backend, filename, profile):
     assert backend in ['aws', 'gcp', 'local'], "Backend not supported!"
 
     if backend == 'aws':

--- a/strato/commands/rm.py
+++ b/strato/commands/rm.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Optional
 
 example_text = """Examples:
   strato rm --backend aws s3://my-bucket/file1 s3://my-bucket/folder2/
@@ -7,21 +6,21 @@ example_text = """Examples:
   strato rm --backend local file1 folder2
 """
 
-def delete_files(backend, recursive, parallel, filenames, profile: Optional[str] = None):
+def delete_files(backend, recursive, parallel, filenames, profile, quiet):
     assert backend in ['aws', 'gcp', 'local'], "Backend not supported!"
 
     if backend == 'aws':
         from strato.backends import AWSBackend
         be = AWSBackend()
-        be.delete(filenames, profile)
+        be.delete(filenames, profile, quiet)
     elif backend == 'gcp':
         from strato.backends import GCPBackend
         be = GCPBackend()
-        be.delete(recursive, parallel, filenames)
+        be.delete(recursive, parallel, filenames, quiet)
     else:
         from strato.backends import LocalBackend
         be = LocalBackend()
-        be.delete(recursive, filenames)
+        be.delete(recursive, filenames, quiet)
 
 def main(argsv):
     parser = argparse.ArgumentParser(
@@ -33,7 +32,8 @@ def main(argsv):
     parser.add_argument('--profile', dest='profile', type=str, action='store', help='AWS profile. Only works for aws backend, and use the default profile if not provided.')
     parser.add_argument('-r', dest='recursive', action='store_true', help="Recursive deletion. Not needed for AWS backend.")
     parser.add_argument('-m', dest='parallel', action='store_true', help="Run operations in parallel. Only available for GCP backend.")
+    parser.add_argument('--quiet', dest='quiet', action='store_true', help="Hide the underlying cloud command.")
     parser.add_argument('files', metavar='filenames', type=str, nargs='+', help='List of file paths.')
 
     args = parser.parse_args(argsv)
-    delete_files(args.backend, args.recursive, args.parallel, args.files, args.profile)
+    delete_files(args.backend, args.recursive, args.parallel, args.files, args.profile, args.quiet)

--- a/strato/commands/sync.py
+++ b/strato/commands/sync.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Optional
 
 example_text = """Examples:
   strato sync --backend aws source_folder s3://my-bucket/target_folder
@@ -7,21 +6,21 @@ example_text = """Examples:
   strato sync --backend local source_folder target_folder
 """
 
-def synchronize_folders(backend, parallel, ionice, source, target, profile: Optional[str] = None):
+def synchronize_folders(backend, parallel, ionice, source, target, profile, quiet):
     assert backend in ['aws', 'gcp', 'local'], "Backend not supported!"
 
     if backend == 'aws':
         from strato.backends import AWSBackend
         be = AWSBackend()
-        be.sync(ionice, source, target, profile)
+        be.sync(ionice, source, target, profile, quiet)
     elif backend == 'gcp':
         from strato.backends import GCPBackend
         be = GCPBackend()
-        be.sync(parallel, ionice, source, target)
+        be.sync(parallel, ionice, source, target, quiet)
     else:
         from strato.backends import LocalBackend
         be = LocalBackend()
-        be.sync(ionice, source, target)
+        be.sync(ionice, source, target, quiet)
 
 def main(argsv):
     parser = argparse.ArgumentParser(
@@ -33,8 +32,9 @@ def main(argsv):
     parser.add_argument('-m', dest='parallel', action='store_true', help="Run operations in parallel. Only available for GCP backend.")
     parser.add_argument('--ionice', dest='ionice', action='store_true', help="Run with ionice to avoid monopolizing local disk's I/O. Only available for Linux.")
     parser.add_argument('--profile', dest='profile', type=str, action='store', help='AWS profile. Only works for aws backend, and use the default profile if not provided.')
+    parser.add_argument('--quiet', dest='quiet', action='store_true', help="Hide the underlying cloud command.")
     parser.add_argument('source', metavar='source', type=str, help='Source folder path.')
     parser.add_argument('target', metavar='target', type=str, help='Target folder path.')
 
     args = parser.parse_args(argsv)
-    synchronize_folders(args.backend, args.parallel, args.ionice, args.source, args.target, args.profile)
+    synchronize_folders(args.backend, args.parallel, args.ionice, args.source, args.target, args.profile, args.quiet)


### PR DESCRIPTION
* Add `--quiet` option to **cp**, **sync** and **rm** commands, for the case of hiding the underlying cloud commands to be executed.
* No need to set default value for `profile` argument, as its default is implicitly set to `None` in `argparse.ArgumentParser.add_argument` function.