### PR TITLE
Fix bug for AWS backend wildcard copy

### DIFF
--- a/strato/backends/_aws.py
+++ b/strato/backends/_aws.py
@@ -38,9 +38,10 @@ class AWSBackend:
         for source in source_files:
             subcall_args = call_args.copy()
             subcall_target = target
-            if ('*' in source) and (source.startswith('s3://')): # S3 URI containing wildcards
+            if ('*' in source) and (source.startswith('s3://')):
+                # S3 URI containing wildcards
                 parent_folder, wildcard = parse_wildcard(source)
-                subcall_args.extend(['--recursive', '--include', f"\"{wildcard}\""])
+                subcall_args.extend(['--recursive', '--exclude', '*', '--include', f'{wildcard}', '--dryrun'])
                 source = parent_folder + '/'
             elif source[-1] == '/': # copy an S3 folder
                 subcall_args.append('--recursive')


### PR DESCRIPTION
* Attach `--exclude "*"` ahead to enforce the wildcard matches to the end, not just includes.
* Drop quotes in call argument list fed to `subprocess.check_call` function, as quotes here behave different from in Shell, and thus are not needed.