### PR TITLE
bug fix for AWS backend copy

### DIFF
--- a/strato/backends/_aws.py
+++ b/strato/backends/_aws.py
@@ -1,7 +1,7 @@
 import os, shutil
 import boto3
 from subprocess import check_call, CalledProcessError
-from typing import Optional
+
 
 def parse_wildcard(filepath):
     prefix = "s3://" if filepath.startswith("s3://") else ""
@@ -14,6 +14,9 @@ def parse_wildcard(filepath):
     assert wd_idx != -1, "The given path doesn't contain wildcard!"
 
     parent_folder = prefix + '/'.join(fp_list[0:wd_idx])
+    if parent_folder == "" and prefix == "":
+        parent_folder = "."
+
     wildcard = '/'.join(fp_list[wd_idx:])
 
     return parent_folder, wildcard


### PR DESCRIPTION
## Issue

If source path is local and contains wildcards at top level folder, i.e.
```
strato cp --backend aws *.txt s3://some-bucket-folder
```
This will results in the following aws command:
```
aws s3 cp --only-show-errors --recursive --exclude * --include *.py / s3://some-bucket-folder
```
which incorrectly copies `/*.py`, instead of `./*.py`, to the target folder.

## Solution

In `parse_wildcard` auxiliary function, if `parent_folder` is empty and the given path is a local path, set it to `.` to refer to the current working directory.