### PR TITLE
Made boto3 optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,15 +31,11 @@ classifiers = [
 ]
 
 requires-python = '>=3'
-dependencies = ['boto3']
+dependencies = []
 
 [project.optional-dependencies]
-
-test = [
-    'pytest',
-]
-
-
+aws = ['boto3']
+test = ['pytest']
 
 [tool.black]
 line-length = 100

--- a/strato/backends/_aws.py
+++ b/strato/backends/_aws.py
@@ -2,8 +2,6 @@ import os
 import shutil
 from subprocess import CalledProcessError, check_call
 
-import boto3
-
 
 def parse_wildcard(filepath):
     prefix = "s3://" if filepath.startswith("s3://") else ""
@@ -108,6 +106,8 @@ class AWSBackend:
         is_folder = True if filename[-1] == "/" else False
 
         if is_folder:
+            import boto3
+
             fn_list = filename[5:].split("/")
             bucket = fn_list[0]
             folder = "/".join(fn_list[1:]) if len(fn_list) > 1 else ""


### PR DESCRIPTION
boto3 requires an older version of botocore (botocore>=1.29.86,<1.30.0), which can conflict with other libraries