### PR TITLE
Use s3fs for strato exists on AWS folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 __pycache__/
 *.egg-info/
 version.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-boto3
+s3fs
 importlib_metadata>=0.7; python_version < '3.8'

--- a/strato/backends/_aws.py
+++ b/strato/backends/_aws.py
@@ -2,8 +2,6 @@ import os
 import shutil
 from subprocess import CalledProcessError, check_call
 
-import boto3
-
 
 def parse_wildcard(filepath):
     prefix = "s3://" if filepath.startswith("s3://") else ""
@@ -113,12 +111,10 @@ class AWSBackend:
             fn_list = filename[5:].split("/")
             bucket = fn_list[0]
             folder = "/".join(fn_list[1:]) if len(fn_list) > 1 else ""
-            session = boto3.Session(profile_name=profile)
-            resp = session.client("s3").list_objects_v2(
-                Bucket=bucket,
-                Prefix=folder,
-            )
-            if resp["KeyCount"] == 0:
+
+            from s3fs import S3FileSystem
+            s3 = S3FileSystem(anon=False, profile=profile)
+            if len(s3.ls(f"s3://{bucket}/{folder}")) == 0:
                 raise CalledProcessError(
                     returncode=1,
                     cmd=["strato command"],


### PR DESCRIPTION
boto3's latest version has conflicts with s3fs, thus pandas' feature of reading csv files on S3 buckets.

Use s3fs instead of boto3 in `strato exists` command on AWS folders, as this is the only place using boto3. In this way, we can drop boto3, and stick to s3fs.