### PR TITLE
local cp fix

### DIFF
--- a/strato/backends/_local.py
+++ b/strato/backends/_local.py
@@ -10,11 +10,12 @@ class LocalBackend:
     def copy(self, recursive, ionice, filenames, quiet, dryrun):
         assert len(filenames) >= 2, "Either source or destination is missing!"
         target = filenames[-1]
-        call_args1 = ["mkdir", "-p", target]
-        if not quiet or dryrun:
-            print(" ".join(call_args1))
-        if not dryrun:
-            check_call(call_args1)
+        if recursive:  # only create intermediate directories if copying recursively
+            call_args1 = ["mkdir", "-p", target]
+            if not quiet or dryrun:
+                print(" ".join(call_args1))
+            if not dryrun:
+                check_call(call_args1)
 
         call_args = (
             ["ionice", "-c", "2", "-n", "7"]

--- a/strato/tests/test_cp.py
+++ b/strato/tests/test_cp.py
@@ -15,7 +15,7 @@ def trailing_slash(request):
 
 
 def test_cp_dir_aws(capsys, trailing_slash):
-    cp.main(["dir1", "s3://foo/bar" + "/" if trailing_slash else "", "-r", "--dryrun"])
+    cp.main(["dir1", "s3://foo/bar" + ("/" if trailing_slash else ""), "-r", "--dryrun"])
 
     assert (
         "aws s3 cp --only-show-errors --recursive dir1/ s3://foo/bar/dir1\n"
@@ -34,6 +34,10 @@ def test_cp_dir_gcp(capsys):
 
 
 def test_cp_file_local(capsys):
-    # FIXME only the parent directory should be created
     cp.main(["file1", "/bar/foo", "--dryrun"])
-    assert "mkdir -p /bar/foo\ncp file1 /bar/foo\n" == capsys.readouterr().out
+    assert "cp file1 /bar/foo\n" == capsys.readouterr().out
+
+
+def test_cp_dir_local(capsys):
+    cp.main(["file1", "/bar/foo", "-r", "--dryrun"])
+    assert "mkdir -p /bar/foo\ncp -r file1 /bar/foo\n" == capsys.readouterr().out


### PR DESCRIPTION
for local cp, only create intermediate dirs when recursive as currently not possible to specify full destination path when copying a single file (always creates additional directory)